### PR TITLE
Better exploit in test, throw when found

### DIFF
--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -534,10 +534,15 @@ namespace CKAN
                 }
             }
 
+            if (outputName.Contains("/../") || outputName.EndsWith("/.."))
+            {
+                throw new BadInstallLocationKraken(
+                    string.Format(Properties.Resources.ModuleInstallDescriptorInvalidInstallPath,
+                                  outputName));
+            }
+
             // Return our snipped, normalised, and ready to go output filename!
-            return CKANPathUtils.NormalizePath(
-                Path.Combine(installDir, outputName)
-            );
+            return CKANPathUtils.NormalizePath(Path.Combine(installDir, outputName));
         }
 
         private string ShortestMatchingPrefix(string fullPath)


### PR DESCRIPTION
Hi @rhckrtu,

Thanks for raising this!

I don't think the test as currently written would be an effective exploit because when `file` matches a zip entry, the parent dirs are discarded. But _child_ dirs are supposed to be installed recursively, so that should work; I've revised the test to reflect this and added a fix to throw an exception if an exploit is attempted.

Cheers!
